### PR TITLE
add fields (username, phonetic, alternate)

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -27,7 +27,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-const FILERENAMING_TAGS = ['[idnumber]', '[lastname]', '[firstname]', '[fullname]', '[assignmentname]', '[group]', '[filename]', '[filenumber]'];
+const FILERENAMING_TAGS = ['[idnumber]', '[lastname]', '[firstname]', '[fullname]', '[lastnamephonetic]', '[firstnamephonetic]', '[username]', '[alternatename]', '[assignmentname]', '[group]', '[filename]', '[filenumber]'];
 
 /**
  * File rename function
@@ -46,7 +46,7 @@ function filerenaming_rename_file($prefixedfilename, $original, $user, $assign, 
     global $CFG;
 
     // Select filerenaming pattern out of (session|moodle default) in this order.
-    $placeholders = ['[idnumber]', '[lastname]', '[firstname]', '[fullname]', '[assignmentname]', '[group]', '[filename]', '[filenumber]'];
+    $placeholders = ['[idnumber]', '[lastname]', '[firstname]', '[fullname]', '[lastnamephonetic]', '[firstnamephonetic]', '[username]', '[alternatename]', '[assignmentname]', '[group]', '[filename]', '[filenumber]'];
     $filerenaminguserpref = get_user_preferences('filerenamingpattern', '');
     $o = '';
     if (ispatternvalid(FILERENAMING_TAGS, $filerenaminguserpref)) {
@@ -101,11 +101,19 @@ function filerenaming_rename_file($prefixedfilename, $original, $user, $assign, 
         $o = (strpos($o, $blind) === false) ? str_replace('[fullname]',  $blind, $o) : str_replace('[fullname]',  '', $o);
         $o = (strpos($o, $blind) === false) ? str_replace('[firstname]', $blind, $o) : str_replace('[firstname]', '', $o);
         $o = (strpos($o, $blind) === false) ? str_replace('[lastname]',  $blind, $o) : str_replace('[lastname]',  '', $o);
+        $o = (strpos($o, $blind) === false) ? str_replace('[username]',  $blind, $o) : str_replace('[username]',  '', $o);
+        $o = (strpos($o, $blind) === false) ? str_replace('[alternatename]',  $blind, $o) : str_replace('[alternatename]',  '', $o);
+        $o = (strpos($o, $blind) === false) ? str_replace('[firstnamephonetic]', $blind, $o) : str_replace('[firstnamephonetic]', '', $o);
+        $o = (strpos($o, $blind) === false) ? str_replace('[lastnamephonetic]',  $blind, $o) : str_replace('[lastnamephonetic]',  '', $o);
     } else {
         $o = str_replace('[idnumber]',  $user->idnumber, $o);
         $o = str_replace('[fullname]',  fullname($user), $o);
         $o = str_replace('[firstname]', $user->firstname, $o);
         $o = str_replace('[lastname]',  $user->lastname, $o);
+        $o = str_replace('[username]',  $user->username, $o);
+        $o = str_replace('[alternatename]',  $user->alternatename, $o);
+        $o = str_replace('[firstnamephonetic]', $user->firstnamephonetic, $o);
+        $o = str_replace('[lastnamephonetic]',  $user->lastnamephonetic, $o);
     }
 
     $o = replace_custom($o, $maxlength, '[assignmentname]', $assignmentname);


### PR DESCRIPTION
Thanks a lot for this plug-in.

The field "username" is most important for schools in Japan. "lastnamephonetic", "firstnamephonetic", "alternatename" are also important.

For example, a student in our college has:

|field|content|[ISO 15924](https://en.wikipedia.org/wiki/ISO_15924)|
|-----|-------|--------|
|username|z23001 (= student id number)|[a-z][0-9]+|
|firstname|太郎|all Unicode characters and [IVS](https://ja.wikipedia.org/wiki/%E7%95%B0%E4%BD%93%E5%AD%97%E3%82%BB%E3%83%AC%E3%82%AF%E3%82%BF) are acceptable|
lastname|山田|all Unicode characters and [IVS](https://ja.wikipedia.org/wiki/%E7%95%B0%E4%BD%93%E5%AD%97%E3%82%BB%E3%83%AC%E3%82%AF%E3%82%BF) are acceptable|
|firstnamephonetic|タロウ (for collations)|Kana|
lastnamephonetic|ヤマダ (for collations)|Kana|
|alternatename|YAMADA Taro|Latn (without diacritical mark)|

Non-Japanese teachers are able to identify him by alternatename.

I'm sorry not to edit ptablepdf.php .