### PR TITLE
Convert characters to ascii before cleaning up file names

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -225,6 +225,7 @@ function clean_custom($filename) {
 
     $cleanfilenameuserpref = get_user_preferences('clean_filerenaming', '');
     if ((isset($cleanfilenameuserpref) && $cleanfilenameuserpref)) {
+        $filename = core_text::specialtoascii($filename);
         $filename = preg_replace('/[^A-Za-z0-9\_\-\.]/', '', $filename);
     }
     return clean_filename($filename);


### PR DESCRIPTION
We have installed your plugin in my institution and it works great. Thank you for sharing this useful plugin.

We have just added a minor patch.

Currently, when you enable the `clean filenames` option, the characters with diacritics are removed.

E.g., a file named `élèves groupe 5.zip` becomes `lves_groupe_5.zip`

Our patch replaces accented letters with their unaccented equivalents.

So, with the example above, the file name becomes `eleves_groupe_5.zip`

If you are not interested in this change, you can close this PR. No problem. :)
